### PR TITLE
Feature: Ecoportal global UI fixes

### DIFF
--- a/app/assets/stylesheets/theme-variables.scss.erb
+++ b/app/assets/stylesheets/theme-variables.scss.erb
@@ -28,7 +28,7 @@
     <% when "ecoportal" %>
     :root{
         --primary-color: #0f4e8a;
-        --hover-color: #6B96B7;
+        --hover-color: #0f4e8a;
         --secondary-color: #ffc107;
     }
     <%# Here to add a new theme ... %>

--- a/app/assets/stylesheets/themes/ecoportal/main.scss
+++ b/app/assets/stylesheets/themes/ecoportal/main.scss
@@ -9,7 +9,7 @@ $color-warning: #ffc107;
 
 body {
   font-family: "Titillium Web";
-  font-size: 14px;
+  font-size: 16px !important;
 }
 
 .minimal {

--- a/app/assets/stylesheets/themes/ecoportal/main.scss
+++ b/app/assets/stylesheets/themes/ecoportal/main.scss
@@ -90,3 +90,13 @@ tr.mainresource td {
 .ont_icons {
   font-family: "Titillium Web", Lucida Console, Monaco, monospace;
 }
+
+footer, .footer {
+  background-color: $color-primary !important;
+  position: relative !important;
+  padding: 30px 0;
+  color: white !important;
+  a {
+    color: white !important;
+  }
+}

--- a/app/assets/stylesheets/themes/lirmm/app.scss
+++ b/app/assets/stylesheets/themes/lirmm/app.scss
@@ -60,8 +60,6 @@ body.ontologies.index {
   .new_ontology_button {
     display: inline-block;
     width: 100%;
-    padding-left: 0px !important;
-    padding-right: 0px !important;
     margin-top: 1em;
   }
 

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -3,7 +3,7 @@
 %head
   = javascript_include_tag "bp_annotator"
 
-%div.container-fluid
+%div.container-fluid.flex-grow-1
   %div.row
     %div.col
       %h2.mt-3 Annotator

--- a/app/views/annotatorplus/index.html.haml
+++ b/app/views/annotatorplus/index.html.haml
@@ -3,7 +3,7 @@
 %head
   = javascript_include_tag "bp_annotatorplus"
 
-%div.container-fluid
+%div.container-fluid.flex-grow-1
   %div.row
     %div.col
       %h2.mt-3 Annotator &plus;

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -18,7 +18,7 @@
   %div.row
     %div.col
       %div.px-2.py-2.pt-md-5.border-bottom.text-center
-        %h2
+        %h1
           = t(".welcome", site: "#{$SITE}")
           %small.text-muted
             = t(".tagline")

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -91,41 +91,6 @@
   - if fairness_service_enabled?
     %div#fair-home.row.mt-3
       = render partial: "fair_score_home"
-  %div.row.pt-3.extra
-    %div.col
-      %div.card-deck
-        -# Latest Notes
-        %div.card
-          %div.card-header Latest Notes
-          %ul.list-group.list-group-flush
-            - if @last_notes.nil? || @last_notes.empty?
-              %li.list-group-item
-                %span No recent notes have been submitted
-            - else
-              - for note in @last_notes
-                %li.list-group-item
-                  - begin
-                    = link_to "#{note[:subject]} (#{note[:ont_name]})", note_path(CGI.escape(note[:id]))
-                    %br/
-                    %span{:style => "color: #AAAAAA"}
-                      = "#{time_ago_in_words(note[:created])} ago"
-                      by #{note[:author]}
-                    - if note[:body]
-                      %p
-                        = truncate(strip_tags(note[:body]), :length => 100)
-                        \&nbsp;
-                  - rescue
-        - if !$ENABLE_SLICES.nil? && $ENABLE_SLICES == true && !at_slice?
-          -# Slices
-          %div.card
-            %div.card-header Slices
-            %ul.list-group.list-group-flush
-              - LinkedData::Client::Models::Slice.all.each_with_index do |slice, index|
-                - break if index == 10
-                - slice_name = "#{slice.name} (#{slice.acronym})"
-                - slice_link = "http://#{slice.acronym}.#{$UI_URL.sub("http://", "")}"
-                %li.list-group-item
-                  = link_to slice_name, slice_link
 
 
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -43,5 +43,5 @@
 <body class="<%= controller_name %> <%= action_name %>">
   <%=render partial: 'layouts/topnav'%>
   
-  <div class="container-fluid">
+  <div class="container-fluid flex-grow-1">
     <%=render partial: 'layouts/notices'%>

--- a/app/views/layouts/appliance.html.haml
+++ b/app/views/layouts/appliance.html.haml
@@ -28,7 +28,7 @@
   %body{:class => "#{controller_name} #{action_name}"}
     = render partial: "layouts/topnav"
     
-    %div.container-fluid
+    %div.container-fluid.flex-grow-1
       = render partial: "layouts/notices"
       = render TurboModalComponent.new(id: 'application_modal')
       = yield

--- a/app/views/mappings/index.html.haml
+++ b/app/views/mappings/index.html.haml
@@ -1,5 +1,5 @@
 - @title = "Mappings"
-%div#mappings_container.container-fluid.py-4
+%div#mappings_container.container-fluid.py-4.flex-grow-1
   %h1.my-1 Mappings
 
   %div#mappings_uploader.my-2

--- a/app/views/ncbo_annotatorplus/index.html.haml
+++ b/app/views/ncbo_annotatorplus/index.html.haml
@@ -3,7 +3,7 @@
 %head
   = javascript_include_tag "bp_annotator"
 
-%div.container-fluid.annotator
+%div.container-fluid.annotator.flex-grow-1
   %div.row
     %div.col
       %h2.mt-3 NCBO Annotator +


### PR DESCRIPTION


### Description 

Made some global UI fixes, to have the following result 

### Home page
![image](https://github.com/lifewatch-eric/ecoportal_web_ui/assets/29259906/3d0eef63-279c-4a64-9f32-0a4c365630ed)


### Browse page
![image](https://github.com/lifewatch-eric/ecoportal_web_ui/assets/29259906/67bfcd3e-ce18-4c16-9bae-634cbf183fe7)

### Login page
![image](https://github.com/lifewatch-eric/ecoportal_web_ui/assets/29259906/4f5e5483-6e4d-4b6b-8fa8-c0ab92c3f489)

### Changes

 - Remove slices and latest-notes section on the home page (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/35183d656874d31124fac0a5f778d42a3d131eb3)


- Make homepage description text an "h1" instead of "h2" (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/d84940e92fa71efe266517795034775e3bb8282f)


- Fix browser new ontology button padding (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/3adb4eed18ac137ae20e6c9be04cb7b7a506cd2a)


- Fix Ecoportal hover-color theme variable (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/341d4b3a40aa037bc1cc9ca9a384edf5e728ba06)


- Make Ecoportal font size bigger by default (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/a3b1adab9be345c927fa82797d755bc9e15ab142)


- Fix Ecoportal footer text color (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/b36d65c086ab23dab589021b9db833ab833f878a)