### PR TITLE
Feature: Make metadata curator work Agents and have a better display of them 

### DIFF
--- a/app/components/agent_search_input_component/agent_search_input_component.html.haml
+++ b/app/components/agent_search_input_component/agent_search_input_component.html.haml
@@ -1,5 +1,5 @@
 = render SearchInputComponent.new(name:'agent' + @id, ajax_url: "/ajax/agents?agent_type=#{@agent_type}&name=",
-     item_base_url:"/agents/#{@id}?parent_id=#{@parent_id}&edit_on_modal=#{@edit_on_modal}&name_prefix=#{@name_prefix}&name=", id_key: 'name',
+     item_base_url:"/agents/#{@id}?parent_id=#{@parent_id}&edit_on_modal=#{@edit_on_modal}&name_prefix=#{@name_prefix}&agent_id=", id_key: 'id',
      use_cache: false,
      actions_links: {create_new_agent: {link: "/agents/new?name=&id=#{@id}&parent_id=#{@parent_id}&new_agent=false&type=#{@agent_type}&show_affiliations=false&edit_on_modal=#{@edit_on_modal}&name_prefix=#{@name_prefix}[#{@id}]", target:'_self'}}) do |s|
   - s.template do

--- a/app/components/nested_agent_search_input_component/nested_agent_search_input_component.html.haml
+++ b/app/components/nested_agent_search_input_component/nested_agent_search_input_component.html.haml
@@ -3,6 +3,10 @@
     = render TurboFrameComponent.new(id: agent_id_frame_id('NEW_RECORD', @parent_id)) do
       = render AgentSearchInputComponent.new(id: 'NEW_RECORD', agent_type: @agent_type, name_prefix: @name_prefix,
                                              parent_id: @parent_id, edit_on_modal: @edit_on_modal)
+
+  - c.empty_state do
+    = hidden_field_tag agent_field_name('',  @name_prefix+"[#{Array(@agents).size}]")
   - Array(@agents).each_with_index do |agent, i|
-    - c.row do
-      = render partial: 'agents/agent_show', locals: {agent: agent, name_prefix: @name_prefix+"[#{i}]", edit_on_modal: @edit_on_modal, parent_id: @parent_id}
+    - if agent
+      - c.row do
+        = render partial: 'agents/agent_show', locals: {agent: agent, name_prefix: @name_prefix+"[#{i}]", edit_on_modal: @edit_on_modal, parent_id: @parent_id}

--- a/app/components/nested_form_inputs_component.rb
+++ b/app/components/nested_form_inputs_component.rb
@@ -4,4 +4,5 @@ class NestedFormInputsComponent < ViewComponent::Base
 
   renders_one :template
   renders_many :rows
+  renders_one :empty_state
 end

--- a/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
+++ b/app/components/nested_form_inputs_component/nested_form_inputs_component.html.haml
@@ -6,14 +6,15 @@
       %div.d-flex.justify-content-end{style: 'width: 10%'}
         %button.btn.btn-primary{data: {action:"nested-form#remove"}}
           %i.fas.fa-minus.fa-lg
+  %div.d-none
+    = empty_state
   - rows.each_with_index  do |row , index|
     %div.d-flex.align-items-center.nested-form-wrapper.my-1{'data-new-record': 'true'}
       %div{style: 'width: 90%'}
         = row
       %div.d-flex.justify-content-end{style: 'width: 10%'}
-        - unless index == 0
-          %button.btn.btn-primary{data: {action:"nested-form#remove"}}
-            %i.fas.fa-minus.fa-lg
+        %button.btn.btn-primary{data: {action:"nested-form#remove"}}
+          %i.fas.fa-minus.fa-lg
 
   %div{'data-nested-form-target': "target"}
   %div.float-right

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -7,7 +7,9 @@ class AgentsController < ApplicationController
   end
 
   def show
-    @agent = LinkedData::Client::Models::Agent.all(name: params[:name]).find { |x| x.name.eql?(params[:name]) }
+    @agent = LinkedData::Client::Models::Agent.find(params[:agent_id])
+    not_found("Agent with id #{@agent.id}") if @agent.nil?
+
     @agent_id = params[:id] || agent_id(@agent)
     @name_prefix = params[:name_prefix] ? "#{params[:name_prefix]}[#{params[:id]}]" : ''
     @edit_on_modal = params[:edit_on_modal]&.eql?('true')

--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -18,16 +18,21 @@ module SubmissionUpdater
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(new_submission_hash[:ontology]).first
     @submission = @ontology.explore.submissions({ display: 'all' }, new_submission_hash[:id])
 
-    @submission.update_from_params(submission_params(new_submission_hash))
+    new_values = submission_params(new_submission_hash)
+    new_values.each do |key, values|
+      @submission.send("#{key}=", values)
+    rescue StandardError
+      next
+    end
 
     update_ontology_summary_only
-    @submission.update(cache_refresh_all: false)
+    @submission.update(values: new_values, cache_refresh_all: false)
   end
 
   private
 
-  def update_ontology_summary_only
-    @ontology.summaryOnly = @submission.isRemote.eql?('3')
+  def update_ontology_summary_only(is_remote = @submission.isRemote)
+    @ontology.summaryOnly = is_remote&.eql?('3')
     @ontology.update
   end
 
@@ -108,7 +113,7 @@ module SubmissionUpdater
       m_attr = m['attribute'].to_sym
       if p[m_attr] && m['enforce'].include?('list')
         p[m_attr] = Array(p[m_attr]) unless p[m_attr].is_a?(Array)
-        p[m_attr] = p[m_attr].map { |x| x.is_a?(Hash) ? x.values : x }.flatten.uniq if m['enforce'].include?('Agent')
+        p[m_attr] = p[m_attr].map { |x| x.is_a?(Hash) ? x.values.reject(&:empty?) : x.reject(&:empty?) }.flatten.uniq if m['enforce'].include?('Agent')
       end
     end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -69,8 +69,6 @@ class SubmissionsController < ApplicationController
   def update
     error_responses = []
     _, submission_params = params[:submission].each.first
-    @required_only = !params['required-only'].nil?
-    @filters_disabled = true
 
     error_responses << update_submission(submission_params)
 
@@ -78,10 +76,13 @@ class SubmissionsController < ApplicationController
       @errors = error_responses.map { |error_response| response_errors(error_response) }
     end
 
-    if @errors
+    if @errors && !params[:attribute]
+      @required_only = !params['required-only'].nil?
+      @filters_disabled = true
       reset_agent_attributes
       render 'edit', status: 422
     elsif params[:attribute]
+      reset_agent_attributes
       render_submission_attribute(params[:attribute])
     else
       submit_new_doi_request if doi_requested?

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -180,7 +180,18 @@ module OntologiesHelper
           else
 
             # SINGLE METADATA
-            if !sub.send(metadata).nil?
+            if agent?(json_metadata, metadata)
+              next if sub.send(metadata).nil?
+
+              html << content_tag(:tr) do
+                if label.nil?
+                  concat(content_tag(:td, metadata.gsub(/(?=[A-Z])/, " ")))
+                else
+                  concat(content_tag(:td, label))
+                end
+                concat(content_tag(:td, raw("<div> #{display_agent(sub.send(metadata))} </div>")))
+              end
+            elsif !sub.send(metadata).nil?
               html << content_tag(:tr) do
                 if label.nil?
                   concat(content_tag(:td, metadata.gsub(/(?=[A-Z])/, " ")))

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -49,10 +49,10 @@ module SubmissionsHelper
 
   def attribute_container(attr, required: false, &block)
     if show_attribute?(attr, required)
-      content_tag(:div) do
-        capture(&block)
-      end
+    content_tag(:div) do
+      capture(&block)
     end
+  end
   end
 
   def inline_save?
@@ -360,6 +360,11 @@ module SubmissionsHelper
       c.template do
         method(field_func).call("#{name}[NEW_RECORD]", '', :id => attr["attribute"].to_s + "_" + @ontology.acronym, class: "metadataInput form-control my-1")
       end
+
+      c.empty_state do
+        hidden_field_tag "#{name}[#{values.size}]"
+      end
+
       values.each_with_index do |metadata_val, i|
         c.row do
           method(field_func).call("#{name}[#{i}]", metadata_val, :id => "submission_#{attr["attribute"].to_s}" + "_" + @ontology.acronym, class: "metadataInput my-1 form-control")

--- a/app/views/agents/_form.html.haml
+++ b/app/views/agents/_form.html.haml
@@ -67,7 +67,8 @@
               = text_field_tag agent_identifier_name('NEW_RECORD' , :notation, name_prefix), '', class: "form-control"
               - values = %w[ORCID ROR ISNI GRID]
               = render SelectInputComponent.new(id: "agent_identifiers_schemaAgency_NEW_RECORD", name: agent_identifier_name('NEW_RECORD', :schemaAgency, name_prefix), values: values, selected: 'ORCID')
-
+          - c.empty_state do
+            = hidden_field_tag agent_field_name('',  name_prefix+"[#{Array(agent.identifiers).size}]")
           - Array(agent.identifiers).each_with_index do |identifier, i|
             - c.row do
               %div.d-flex{id: identifier.id}

--- a/app/views/agents/_table_list.html.haml
+++ b/app/views/agents/_table_list.html.haml
@@ -12,3 +12,7 @@
       = render partial: 'agents/show_line' , locals: {agent: agent}
     %tr.empty-state
       %td.text-center{:colspan => "6"} There are currently no  agents.
+:javascript
+  $.fn.dataTable.ext.errMode = 'none';
+
+  $("#adminAgents").dataTable()

--- a/app/views/ontologies_metadata_curator/_attribute_inline.html.haml
+++ b/app/views/ontologies_metadata_curator/_attribute_inline.html.haml
@@ -21,7 +21,13 @@
   - elsif attribute == "ontology"
     = acronym
   - else
-    - if submission.instance_values[attribute.to_s].class == String && submission.instance_values[attribute.to_s][0..3] == "http"
+    - if submission.instance_values[attribute.to_s].is_a?(String) && %w[http https].include?(submission.instance_values[attribute.to_s][0..3])
       %a{:href=> ""+ submission.instance_values[attribute.to_s] +""}= submission.instance_values[attribute.to_s]
     - else
-      = submission.instance_values[attribute.to_s]
+      - Array(submission.instance_values[attribute.to_s]).each do |value|
+        - if value.is_a?(LinkedData::Client::Models::Agent)
+          %div
+            = display_agent(value, link: false)
+        - else
+          %p
+            = value

--- a/app/views/submissions/_form_content.html.haml
+++ b/app/views/submissions/_form_content.html.haml
@@ -124,6 +124,8 @@
           = render NestedFormInputsComponent.new do |c|
             - c.template do
               = render partial: "submissions/submission_contact_form", locals: {contact: nil, index: 'NEW_RECORD'}
+            - c.empty_state do
+              = hidden_field_tag object_name+"[contact][#{index.to_s.upcase}][email]"
             - @submission.contact.each_with_index do |contact, i|
               - c.row do
                 = render partial: "submissions/submission_contact_form", locals: {contact: contact, index: i}

--- a/app/views/submissions/_form_content.html.haml
+++ b/app/views/submissions/_form_content.html.haml
@@ -43,8 +43,8 @@
         = form_group_attribute('alternative', required: true)
 
         -# Publications page
-        = attribute_text_field_container('publication', required: true) do |c|
-          - c.help do
+        = form_group_attribute('publication', required: true) do
+          %p
             Enter a URL for a page that lists publications about your ontology.
 
         = form_group_attribute("released", default: Date.today, required: true)

--- a/app/views/submissions/_submission_identifier_form.html.haml
+++ b/app/views/submissions/_submission_identifier_form.html.haml
@@ -1,7 +1,7 @@
-= form_group_attribute("identifier", required: true) do |c|
-  Insert the Persistent Identifier - DOI or other - of your semantic asset
-%div.form-group.row
-  %div.col-sm-8.field-value-col.offset-4{id: "identifier_fields_col"}
+= form_group_attribute("identifier", required: true) do
+  %div
+    Insert the Persistent Identifier - DOI or other - of your semantic asset
+  %div.mt-4{id: "identifier_fields_col"}
     - if @identifier_request && @identifier_request.status == "PENDING"
       .d-flex
         .col-sm-8.sub-label


### PR DESCRIPTION
### Context 
#16 
This PR, in summary, fixes issues with saving submissions, using the metadata curator.

### Changes

- Put the doi request check under the identifier inputs in the submission form (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/82b8c42f9b36f671c6f7d5db5f538358e764ea66)
- Make submission publication using the URL tag input in the submission form (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/4e3dee182b75a4cd761ce76e6e9323848e149f82)
- Update nested form component to have an empty state to send to the back (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/c15662ae17f3bf49fb8b17ce2fbbf7e2be670f7d)
- Add Jquery data table to the admin agents table (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/ce5ca9305c14f6569f8ba67925d8a1dcd6ce8a2e)
- Change agent search input to use its Id instead of name to find it (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/bb0dac17feffecdb6c1bd8268142908c92633d05)
- Fix metadata curator does not save agent update (bug still in changed_values) (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/fae4f9fdc81ec17a5d57b2f6e8194d729b7c5dde)
- Add display agent in the metadata curator (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/fa71437d0f10fce94b44196343d6b24b20172553)
- Update display agent to show agent affiliations (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/ce94f7aff30fdcb9e3ea10f18318e7df02ece2b6)
- Handle the display of no array agents in summary page (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/41224857cc852bf8bb1b355e2925e11dd579d944)

 