### PR TITLE
Fix: add new submission removing old metadata

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  
+
   before_action :unescape_id, only: [:edit, :show, :update]
   before_action :verify_owner, only: [:edit, :show, :subscribe, :un_subscribe]
   before_action :authorize_admin, only: [:index,:subscribe, :un_subscribe]
@@ -231,7 +231,7 @@ class UsersController < ApplicationController
     end
 
     if params[:username].nil? || params[:username].length < 1 || !params[:username].match(/^[a-zA-Z0-9]([._-](?![._-])|[a-zA-Z0-9]){3,18}[a-zA-Z0-9]$/)
-      errors << "Please provide a valid username, which should not be your email address or include any special characters"
+      errors << "please enter a valid username"
     end
     return errors
   end
@@ -250,16 +250,10 @@ class UsersController < ApplicationController
     if params[:username].nil? || params[:username].length < 1
       errors << "Last name field is required"
     end
-    if params[:orcidId] && ((!params[:orcidId].match(/^\d{4}+(-\d{4})+$/)) || (params[:orcidId].length != 19)) && !(params[:orcidId].nil? || params[:orcidId].length < 1)
-      errors << "Please enter a valid orcid id"
+    if params[:orcidId].present? && ((!params[:orcidId].match(/^\d{4}-\d{4}-\d{4}-\d{4}$/)) || (params[:orcidId].length != 19))
+      errors << "Please enter a valide orcide id"
     end
-
-
-    if params[:password].nil? || params[:password].empty?
-      errors << "Your Password can't be empty"
-    end
-
-    if params[:password] && !params[:password].eql?(params[:password_confirmation])
+    if !params[:password].eql?(params[:password_confirmation])
       errors << "Your Password and Password Confirmation do not match"
     end
 

--- a/app/views/ontologies/sections/_metadata.html.haml
+++ b/app/views/ontologies/sections/_metadata.html.haml
@@ -63,7 +63,7 @@
       %div.ont-section-toolbar
         %header.pb-2.font-weight-bold Submissions
         - if @ontology.admin?(session[:user])
-          = link_to(new_ontology_submission_path(@ontology.acronym), "aria-label": "Add submission", title: "Add submission") do
+          = link_to(new_ontology_submission_path(@ontology.acronym, required: false), "aria-label": "Add submission", title: "Add submission") do
             %i.fas.fa-lg.fa-plus-circle{"aria-hidden": "true", style: "margin-left: 0.75rem;"}
           - unless (@submission_latest.nil? || (@submission_latest.respond_to?(:status) && @submission_latest.status == 404))
             = link_to(edit_ontology_submission_path(@ontology.acronym, @submission_latest.submissionId), "aria-label": "Edit latest submission", title: "Edit latest submission") do

--- a/app/views/submissions/_submissions.html.haml
+++ b/app/views/submissions/_submissions.html.haml
@@ -48,9 +48,9 @@
           - if @ontology.admin?(session[:user])
             %td
               %div.d-flex
-                %a.btn.btn-sm.btn-link{:href => "/ontologies/#{@ontology.acronym}/submissions/#{sub.submissionId}/edit", 'data-turbo-frame':"_top"}
-                  %span Edit
-                - unless index.zero?
+                -#%a.btn.btn-sm.btn-link{:href => "/ontologies/#{@ontology.acronym}/submissions/#{sub.submissionId}/edit", 'data-turbo-frame':"_top"}
+                -#  %span Edit
+                - unless sub.submissionId.eql?(submission_readyId)
                   - alert_text = "Are you sure you want to delete submission <span style='color:red;font-weight:bold;'>" + sub.submissionId.to_s + "</span> for ontology <span style='color:red;font-weight:bold;'>" + @ontology.acronym + "</span>?<br/><b>This action CAN NOT be undone!!!</b>"
                   = button_to "Delete", "/admin/ontologies/#{@ontology.acronym}/submissions/#{sub.submissionId}?turbo_stream=true", method: :delete, class:'btn btn-sm btn-link',  form: {data: { turbo: true, turbo_confirm: alert_text, turbo_frame: '_top'}}
 


### PR DESCRIPTION
Add a new submission was removing the old metadata, as shown in the screenshot below 
### Before adding a submission
![image](https://github.com/lifewatch-eric/ecoportal_web_ui/assets/29259906/32ed0ee8-2c08-421e-9dd1-c1c0b591770a)

### After adding a submission
![image](https://github.com/lifewatch-eric/ecoportal_web_ui/assets/29259906/729ac289-8898-4795-bc93-e3f26ea1d964)


The [fix](https://github.com/lifewatch-eric/ecoportal_web_ui/pull/31/commits/4418138da06dfbcc9f0398e482f6058bf9efddd7) was to disable the showing of only the required metadata in the add new submission form, by default (where it was the inverse)

<img width="1188" alt="image" src="https://github.com/lifewatch-eric/ecoportal_web_ui/assets/29259906/90145cec-60c3-409e-9bda-38f90e8576be">
