### PR TITLE
Fix: Disable GA from home and ontologies pages until support the new version of  GA4

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -48,17 +48,17 @@ class HomeController < ApplicationController
     @individuals_count = LinkedData::Client::Models::Metrics.all.map {|m| m.individuals.to_i}.sum
     @prop_count = 36286
     @map_count = total_mapping_count
-    @analytics = LinkedData::Client::Analytics.last_month
+    #@analytics = LinkedData::Client::Analytics.last_month
 
     @ontology_names = @ontologies.map { |ont| ["#{ont.name} (#{ont.acronym})", ont.acronym] }
 
     @anal_ont_names = {}
     @anal_ont_numbers = []
-    @analytics.onts[0..4].each do |visits|
-      ont = @ontologies_hash[visits[:ont].to_s]
-      @anal_ont_names[ont.acronym] = ont.name
-      @anal_ont_numbers << visits[:views]
-    end
+    # @analytics.onts[0..4].each do |visits|
+    #   ont = @ontologies_hash[visits[:ont].to_s]
+    #   @anal_ont_names[ont.acronym] = ont.name
+    #   @anal_ont_numbers << visits[:views]
+    # end
 
 
   end

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -54,8 +54,8 @@ display_context: false, include: browse_attributes)
     @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
     @groups_hash = Hash[@groups.map {|g| [g.id, g] }]
 
-    analytics = LinkedData::Client::Analytics.last_month
-    @analytics = Hash[analytics.onts.map {|o| [o[:ont].to_s, o[:views]]}]
+    #analytics = LinkedData::Client::Analytics.last_month
+    #@analytics = Hash[analytics.onts.map {|o| [o[:ont].to_s, o[:views]]}]
 
     reviews = {}
     LinkedData::Client::Models::Review.all(display_links: false, display_context: false).each do |r|
@@ -93,7 +93,7 @@ display_context: false, include: browse_attributes)
       o[:review_count]     = ont.reviews.length
       o[:project_count]    = ont.projects.length
       o[:private]          = ont.private?
-      o[:popularity]       = @analytics[ont.acronym] || 0
+      #o[:popularity]       = @analytics[ont.acronym] || 0
       o[:submissionStatus] = []
       o[:administeredBy]   = ont.administeredBy
       o[:name]             = ont.name

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -58,12 +58,12 @@
   %div.row.pt-3.statistics
     %div.col
       %div.card-deck
-        -# Ontology visits
-        %div.card
-          %div.card-header Semantic Resource Visits #{"in full #{$SITE} " if at_slice?} (#{@analytics.date.strftime("%B %Y")})
-          = content_tag(:div, nil, id: "ontology-visits-chart", class: "card-body", data: {ontnames: @anal_ont_names, ontnumbers: @anal_ont_numbers}) do
-            %canvas#myChart
-            = link_to("More", visits_path())
+        -# -# Ontology visits
+        -# %div.card
+        -#   %div.card-header Semantic Resource Visits #{"in full #{$SITE} " if at_slice?} (#{@analytics.date.strftime("%B %Y")})
+        -#   = content_tag(:div, nil, id: "ontology-visits-chart", class: "card-body", data: {ontnames: @anal_ont_names, ontnumbers: @anal_ont_numbers}) do
+        -#     %canvas#myChart
+        -#     = link_to("More", visits_path())
         -# Ontology statistics
         %div.card
           %div.card-header #{$SITE} Statistics #{"in full #{$SITE}" if at_slice?}


### PR DESCRIPTION
### Changes 
* Disable GA from home and ontologies pages as the code needs to be updated to support the new version of Google Analytics 4 (https://github.com/lifewatch-eric/ecoportal_web_ui/commit/ded5a6a065eb48ca7e78726b98ec79ef1e1f6f19) , more details can be found in https://github.com/ontoportal/ontoportal-project/issues/30
