### PR TITLE
Only show archives notes to admin users

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -183,6 +183,9 @@ class OntologiesController < ApplicationController
 
   def notes
     @notes = @ontology.explore.notes
+
+    @notes = @notes.reject(&:archived) unless current_user_admin?
+
     @notes_deletable = false
     # TODO_REV: Handle notes deletion
     # @notes.each {|n| @notes_deletable = true if n.deletable?(session[:user])} if @notes.kind_of?(Array)


### PR DESCRIPTION
Fixes #153 

If a note is archived, only the admin users should be able to see it. Added another check to remove the archived notes from the response if the user is not an admin.