### PR TITLE
#159 fix missing private users

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -90,7 +90,7 @@ module SubmissionsHelper
   end
 
   def display_submission_attributes(acronym, attributes, submissionId: nil, inline_save: false)
-    @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(acronym).first
+    @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(acronym, include: 'all').first
     @selected_attributes = attributes
     @inline_save = inline_save
 


### PR DESCRIPTION
Fixes #159 

If the user edits an ontology submission to add users that can access the private resource, when the user saves the edit and refresh the page, the list is still empty.